### PR TITLE
Nicer path syntax

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 88
+extend_ignore = E203

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `redirect` handler to redirect incoming requests to other locations.
+- BACKWARDS INCOMPATIBLE: changed to new `<type:param>` URL parameter syntax.
 
 ### Changed
 - The SQLite database is now opened in read-only mode (`SQLITE_OPEN_READONLY`).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The columns of this table are:
 
 This is a pattern that defines which incoming URL path or paths will be matched by the route. For example:
 
-* `` - matches the root path (`/`)
+* An empty string matches the root path (`/`)
 * `blog/` - matches `/blog/`
 
 Patterns can also be dynamic: they can contain parameters which will be extracted from the path. Parameter syntax is based on similar `<type:name>` functionality in Django and Flask.

--- a/sqlsite/routing.py
+++ b/sqlsite/routing.py
@@ -27,7 +27,7 @@ class MatchedRoute:
         self.url_params = url_params
 
 
-@lru_cache
+@lru_cache(maxsize=64)
 def pattern_to_regex(pattern):
     """
     Convert a pattern containing <type:name> syntax to a regex.

--- a/sqlsite/routing.py
+++ b/sqlsite/routing.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from sqlsite.database import install_function
 
 import re
@@ -26,10 +27,12 @@ class MatchedRoute:
         self.url_params = url_params
 
 
+@lru_cache
 def pattern_to_regex(pattern):
     """
     Convert a pattern containing <type:name> syntax to a regex.
-    Based on similar code in Django.
+    Based on similar code in Django. This is trivially cacheable
+    as the same input pattern will always return the same regex.
     """
     parts = ["^"]
     while True:

--- a/sqlsite/routing.py
+++ b/sqlsite/routing.py
@@ -4,6 +4,16 @@ import re
 
 PATH_MATCH_FUNCTION_NAME = "PATH_MATCH"
 
+PATTERN_COMPONENT_RE = re.compile(r"<(?P<param_type>[a-z]+):(?P<param_name>[a-z_]+)>")
+
+PATTERN_PARAM_TYPES = {
+    "str": "[^/]+",
+    "int": "[0-9]+",
+    "slug": "[-a-zA-Z0-9_]+",
+    "uuid": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    "path": ".+",
+}
+
 
 class MatchedRoute:
     __slots__ = ["pattern", "handler", "config", "exists_query", "url_params"]
@@ -16,15 +26,46 @@ class MatchedRoute:
         self.url_params = url_params
 
 
+def pattern_to_regex(pattern):
+    """
+    Convert a pattern containing <type:name> syntax to a regex.
+    Based on similar code in Django.
+    """
+    parts = ["^"]
+    while True:
+        match = PATTERN_COMPONENT_RE.search(pattern)
+        if not match:
+            parts.append(re.escape(pattern))
+            break
+        parts.append(re.escape(pattern[: match.start()]))
+        pattern = pattern[match.end() :]
+        param_type, param_name = match.group("param_type", "param_name")
+        param_regex = PATTERN_PARAM_TYPES[param_type]
+        parts.append(f"(?P<{param_name}>{param_regex})")
+    parts.append("$")
+    return "".join(parts)
+
+
 def search_path(pattern, path):
-    if pattern.endswith("/$"):
-        pattern = pattern[:-2] + "/?$"
-    return re.search(pattern, path)
+    """
+    Given a pattern (ie the contents of the pattern column in the route table) and the
+    path of an incoming request (without the leading slash), convert the
+    pattern to a regex and return a match object captured from the path
+    """
+    regex = pattern_to_regex(pattern)
+    if regex.endswith("/$"):
+        regex = regex[:-2] + "/?$"
+    return re.search(regex, path)
 
 
 def create_path_match_function(path):
-    def path_match(val):
-        return search_path(val, path) is not None
+    """
+    Given the path of an incoming request, create a function that can be used to
+    check whether a pattern matches the path.
+    """
+
+    def path_match(pattern):
+        return search_path(pattern, path) is not None
 
     return path_match
 

--- a/sqlsite/wsgi.py
+++ b/sqlsite/wsgi.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("sqlsite")
 
 
 def should_append_slash(request):
-    return request.route.pattern.endswith("/$") and not request.path.endswith("/")
+    return request.route.pattern.endswith("/") and not request.path.endswith("/")
 
 
 def method_allowed(request):

--- a/tests/handlers/test_json.py
+++ b/tests/handlers/test_json.py
@@ -6,7 +6,7 @@ import httpx
 
 def test_json_handler(db):
     sql = "WITH t(greeting) AS (VALUES('hello')) SELECT * FROM t"
-    create_route(db, "^$", "json", config=sql)
+    create_route(db, "", "json", config=sql)
     app = make_app(db)
     client = httpx.Client(app=app)
     response = client.get("http://test/")

--- a/tests/handlers/test_redirect.py
+++ b/tests/handlers/test_redirect.py
@@ -6,7 +6,7 @@ import httpx
 
 def test_redirect_handler(db):
     sql = "SELECT '/after/' || :slug || '/'"
-    create_route(db, "^before/(?P<slug>[-a-zA-Z0-9_]+)/$", "redirect", config=sql)
+    create_route(db, "before/<slug:slug>/", "redirect", config=sql)
     app = make_app(db)
     client = httpx.Client(app=app)
     response = client.get("http://test/before/hello/", allow_redirects=False)

--- a/tests/handlers/test_static.py
+++ b/tests/handlers/test_static.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.mark.skip("Something weird is going on with httpx")
 def test_static_handler(db):
-    create_route(db, "^(?P<name>.+)$", "static", config="")
+    create_route(db, "<path:name>", "static", config="")
     create_sqlar_file(db, "hello.txt", b"hello")
     app = make_app(db)
     client = httpx.Client(app=app)

--- a/tests/handlers/test_template.py
+++ b/tests/handlers/test_template.py
@@ -6,7 +6,7 @@ import httpx
 
 
 def test_template_handler(db):
-    create_route(db, "^(?P<name>[a-z]+)/$", "template", config="template.html")
+    create_route(db, "<str:name>/", "template", config="template.html")
     create_sqlar_file(db, "template.html", b"<h1>hello {{ url.name }}</h1>")
     app = make_app(db)
     client = httpx.Client(app=app)
@@ -18,7 +18,7 @@ def test_template_handler(db):
 
 
 def test_template_with_query(db):
-    create_route(db, "^$", "template", config="template.html")
+    create_route(db, "", "template", config="template.html")
     template = """
     {% with name = sql(\"VALUES('sql')\")[0][0] %}
     <h1>hello {{ name }}</h1>
@@ -35,7 +35,7 @@ def test_template_with_query(db):
 
 
 def test_missing_template(db):
-    create_route(db, "^$", "template", config="missingtemplate.html")
+    create_route(db, "", "template", config="missingtemplate.html")
     create_sqlar_file(db, "template.html", b"<h1>hello</h1>")
     app = make_app(db)
     client = httpx.Client(app=app)
@@ -44,7 +44,7 @@ def test_missing_template(db):
 
 
 def test_markdown(db):
-    create_route(db, "^$", "template", config="template.html")
+    create_route(db, "", "template", config="template.html")
     template = b"{{ '# hello markdown' | markdown }}"
     create_sqlar_file(db, "template.html", template)
     app = make_app(db)

--- a/tests/test_exists.py
+++ b/tests/test_exists.py
@@ -18,7 +18,7 @@ def test_missing_exists_query_returns_true(db):
 
 
 def test_exists_query_request(db):
-    create_route(db, "^$", "hello", exists_query="SELECT 0")
+    create_route(db, "", "hello", exists_query="SELECT 0")
     app = make_app(db)
     client = httpx.Client(app=app)
     response = client.get("http://test/")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -4,6 +4,7 @@ from sqlsite.routing import (
     create_path_match_function,
     install_path_match_function,
     PATH_MATCH_FUNCTION_NAME,
+    pattern_to_regex,
     route,
 )
 
@@ -25,8 +26,19 @@ def test_route_match(db):
 def test_path_match_function():
     path_match_function = create_path_match_function("path/")
     assert path_match_function("path/")
-    assert path_match_function("path")
     assert not path_match_function("otherpath/")
+
+
+def test_path_match_function_with_params():
+    path_match_function = create_path_match_function("path/test/")
+    assert path_match_function("path/<str:param>/")
+    assert not path_match_function("path/<int:param/")
+
+
+def test_trailing_slash_behaviour():
+    path_match_function = create_path_match_function("path")
+    assert path_match_function("path")
+    assert path_match_function("path/")
 
 
 def test_install_path_match_function():
@@ -34,3 +46,46 @@ def test_install_path_match_function():
     install_path_match_function(db, "path/")
     sql = f"SELECT {PATH_MATCH_FUNCTION_NAME}('path/')"
     assert db.cursor().execute(sql).fetchone()[0]
+
+
+def test_string_component():
+    pattern = "test/<str:param>/"
+    regex = pattern_to_regex(pattern)
+    assert regex == "^test/(?P<param>[^/]+)/$"
+
+
+def test_int_component():
+    pattern = "test/<int:param>/"
+    regex = pattern_to_regex(pattern)
+    assert regex == "^test/(?P<param>[0-9]+)/$"
+
+
+def test_slug_component():
+    pattern = "test/<slug:param>/"
+    regex = pattern_to_regex(pattern)
+    assert regex == "^test/(?P<param>[-a-zA-Z0-9_]+)/$"
+
+
+def test_uuid_component():
+    pattern = "test/<uuid:param>/"
+    regex = pattern_to_regex(pattern)
+    assert regex == (
+        "^test/"
+        "(?P<param>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$"
+    )
+
+
+def test_path_component():
+    pattern = "test/<path:param>"
+    regex = pattern_to_regex(pattern)
+    assert regex == "^test/(?P<param>.+)$"
+
+
+def test_multiple_components():
+    pattern = "test/<int:first>/<slug:second>/something/<str:third>/"
+    regex = pattern_to_regex(pattern)
+    assert regex == (
+        "^test/(?P<first>[0-9]+)"
+        "/(?P<second>[-a-zA-Z0-9_]+)"
+        "/something/(?P<third>[^/]+)/$"
+    )

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -26,7 +26,7 @@ def test_not_found(db):
 
 
 def test_add_trailing_slash(db):
-    create_route(db, "^hello/$", "hello")
+    create_route(db, "hello/", "hello")
     app = make_app(db)
     client = httpx.Client(app=app)
     response = client.get("http://test/hello", allow_redirects=False)

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -5,7 +5,7 @@ import httpx
 
 
 def test_hello_world(db):
-    create_route(db, "^$", "hello")
+    create_route(db, "", "hello")
     app = make_app(db)
     client = httpx.Client(app=app)
     response = client.get("http://test/")
@@ -16,7 +16,7 @@ def test_hello_world(db):
 
 
 def test_not_found(db):
-    create_route(db, "^$", "hello")
+    create_route(db, "", "hello")
     app = make_app(db)
     client = httpx.Client(app=app)
     response = client.get("http://test/notfound")


### PR DESCRIPTION
Fixes #4.

Switch to nicer `<type:param>`-style URL parameter syntax.