### PR TITLE
SQL in files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `sql` template function now supports `file=` prefix, for loading SQL from a file.
 - The `existsquery` column can now contain a `file=`-prefixed filename.
 - The `json` handler can now use a `file=`-prefixed filename for its config.
+- The `redirect` handler can now use a `file=`-prefixed filename for its config.
 
 ### Changed
 - The SQLite database is now opened in read-only mode (`SQLITE_OPEN_READONLY`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `redirect` handler to redirect incoming requests to other locations.
+- The `sql` template function now supports `file=` prefix, for loading SQL from a file.
 
 ### Changed
 - The SQLite database is now opened in read-only mode (`SQLITE_OPEN_READONLY`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New `redirect` handler to redirect incoming requests to other locations.
 - The `sql` template function now supports `file=` prefix, for loading SQL from a file.
+- The `existsquery` column can now contain a `file=`-prefixed filename.
 
 ### Changed
 - The SQLite database is now opened in read-only mode (`SQLITE_OPEN_READONLY`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `redirect` handler to redirect incoming requests to other locations.
 - The `sql` template function now supports `file=` prefix, for loading SQL from a file.
 - The `existsquery` column can now contain a `file=`-prefixed filename.
+- The `json` handler can now use a `file=`-prefixed filename for its config.
 
 ### Changed
 - The SQLite database is now opened in read-only mode (`SQLITE_OPEN_READONLY`).

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ There is no need to populate the `existsquery` column: the handler will automati
 
 This handler takes the results of a query and serializes it into a list of JSON objects. The `config` field should be the query to execute.
 
+You can also put your query inside a file in the [SQLite Archive](https://sqlite.org/sqlar.html) and use `file=yourfilename.sql` in the `config` column.
+
 ### `redirect` handler
 
 This handler returns a `301 Permanent Redirect` response. The `config` field should be an SQL query that returns the `Location` to redirect to. The SQL query can contain [named parameters](https://sqlite.org/lang_expr.html#varparam) which will be populated with captured values from the route's URL pattern.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ VALUES ('before/<slug:slug>/', 'redirect', 'SELECT "/after/" || :slug || "/"')
 
 Of course, your query can perform any arbirary operations such as looking up redirects in a table etc.
 
+You can also put your query inside a file in the [SQLite Archive](https://sqlite.org/sqlar.html) and use `file=yourfilename.sql` in the `config` column.
+
 ## SQLite Archives
 
 SQLSite stores the HTML templates and static files needed to build your website _inside the SQLite database itself_. To do this, it uses the [SQLite Archive](https://sqlite.org/sqlar.html) format. Please read the SQLite documentation for full details of this feature, but a quick primer is below.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ For example, given the route pattern `blog/<slug:slug>/`, your template may cont
 {% endwith %}
 ```
 
+You can also put your SQL into a file (which, like the template, must be stored inside the SQLite Archive) by passing the filename prefixed with `file=` to the `sql` template function, rather than an SQL string.
+
 #### Rendering Markdown
 
 SQLSite has support for rendering Markdown in your templates using the [Misaka](https://misaka.61924.nl/) library. If Misaka is installed (`pip install misaka`) then a `markdown` filter becomes available in your templates:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ This allows you to check whether a row in the database exists before attempting 
 
 `SELECT EXISTS(SELECT 1 FROM blogpost WHERE slug=:slug)`
 
+You can also put your query inside a file in the [SQLite Archive](https://sqlite.org/sqlar.html) and use `file=yourfilename.sql` in the `existsquery` column.
+
 ## Handlers
 
 ### `template` handler

--- a/sqlsite/exists.py
+++ b/sqlsite/exists.py
@@ -1,6 +1,10 @@
-def run_existsquery(db, query, params):
-    if not query:
+from .sql import maybe_get_sql_from_file
+
+
+def run_existsquery(db, query_or_prefixed_filename, params):
+    if not query_or_prefixed_filename:
         return True
+    query = maybe_get_sql_from_file(db, query_or_prefixed_filename)
     return db.cursor().execute(query, params).fetchone()[0]
 
 

--- a/sqlsite/handlers.py
+++ b/sqlsite/handlers.py
@@ -24,7 +24,7 @@ def hello(request):
 
 
 def json(request):
-    sql = request.route.config
+    sql = maybe_get_sql_from_file(request.db, request.route.config)
     params = request.route.url_params
     results = request.db.cursor().execute(sql, params).fetchall()
     results_with_string_keys_only = [

--- a/sqlsite/handlers.py
+++ b/sqlsite/handlers.py
@@ -93,7 +93,7 @@ def template(request):
 
 
 def redirect(request):
-    sql = request.route.config
+    sql = maybe_get_sql_from_file(request.db, request.route.config)
     params = request.route.url_params
     location = request.db.cursor().execute(sql, params).fetchone()[0]
     return PermanentRedirectResponse(location)

--- a/sqlsite/handlers.py
+++ b/sqlsite/handlers.py
@@ -7,6 +7,7 @@ from .responses import (
     Response,
     StreamingResponse,
 )
+from .sql import maybe_get_sql_from_file
 from mimetypes import guess_type
 
 import jinja2
@@ -78,7 +79,8 @@ def template(request):
         jinja2_env.filters["markdown"] = markdown_filter
     template = jinja2_env.get_template(request.route.config)
 
-    def sql(sql, params=None):
+    def sql(sql_or_prefixed_filename, params=None):
+        sql = maybe_get_sql_from_file(request.db, sql_or_prefixed_filename)
         params = params or {}
         return request.db.cursor().execute(sql, params).fetchall()
 

--- a/sqlsite/sql.py
+++ b/sqlsite/sql.py
@@ -1,0 +1,11 @@
+from . import sqlar
+
+PREFIX = "file="
+
+
+def maybe_get_sql_from_file(db, sql_or_prefixed_filename):
+    if sql_or_prefixed_filename.startswith(PREFIX):
+        filename = sql_or_prefixed_filename[len(PREFIX) :]
+        row = sqlar.get_row(db, filename)
+        return sqlar.get_data(db, row).decode("utf-8")
+    return sql_or_prefixed_filename

--- a/tests/handlers/test_json.py
+++ b/tests/handlers/test_json.py
@@ -1,4 +1,4 @@
-from ..utils import create_route
+from ..utils import create_route, create_sqlar_file
 from sqlsite.wsgi import make_app
 
 import httpx
@@ -7,6 +7,19 @@ import httpx
 def test_json_handler(db):
     sql = "WITH t(greeting) AS (VALUES('hello')) SELECT * FROM t"
     create_route(db, "", "json", config=sql)
+    app = make_app(db)
+    client = httpx.Client(app=app)
+    response = client.get("http://test/")
+    assert response.status_code == 200
+    assert response.json() == [{"greeting": "hello"}]
+    assert response.headers["Content-Type"] == "application/json"
+    assert response.headers["Content-Length"] == "23"
+
+
+def test_json_handler_with_query_in_file(db):
+    sql = "WITH t(greeting) AS (VALUES('hello')) SELECT * FROM t"
+    create_sqlar_file(db, "query.sql", sql.encode())
+    create_route(db, "", "json", config="file=query.sql")
     app = make_app(db)
     client = httpx.Client(app=app)
     response = client.get("http://test/")

--- a/tests/handlers/test_redirect.py
+++ b/tests/handlers/test_redirect.py
@@ -1,4 +1,4 @@
-from ..utils import create_route
+from ..utils import create_route, create_sqlar_file
 from sqlsite.wsgi import make_app
 
 import httpx
@@ -7,6 +7,17 @@ import httpx
 def test_redirect_handler(db):
     sql = "SELECT '/after/' || :slug || '/'"
     create_route(db, "before/<slug:slug>/", "redirect", config=sql)
+    app = make_app(db)
+    client = httpx.Client(app=app)
+    response = client.get("http://test/before/hello/", allow_redirects=False)
+    assert response.status_code == 301
+    assert response.headers["Location"] == "/after/hello/"
+
+
+def test_redirect_with_sql_in_file(db):
+    sql = "SELECT '/after/' || :slug || '/'"
+    create_sqlar_file(db, "query.sql", sql.encode())
+    create_route(db, "before/<slug:slug>/", "redirect", config="file=query.sql")
     app = make_app(db)
     client = httpx.Client(app=app)
     response = client.get("http://test/before/hello/", allow_redirects=False)

--- a/tests/handlers/test_template.py
+++ b/tests/handlers/test_template.py
@@ -20,7 +20,7 @@ def test_template_handler(db):
 def test_template_with_query(db):
     create_route(db, "", "template", config="template.html")
     template = """
-    {% with name = sql(\"VALUES('sql')\")[0][0] %}
+    {% with name = sql("VALUES('sql')")[0][0] %}
     <h1>hello {{ name }}</h1>
     {% endwith %}
     """
@@ -30,6 +30,23 @@ def test_template_with_query(db):
     response = client.get("http://test/")
     assert response.status_code == 200
     assert response.text.strip() == "<h1>hello sql</h1>"
+    assert response.headers["Content-Type"] == "text/html"
+    assert response.headers["Content-Length"] == "21"
+
+
+def test_template_with_query_and_params(db):
+    create_route(db, "", "template", config="template.html")
+    template = """
+    {% with name = sql("VALUES(:arg)", params={"arg": "arg"})[0][0] %}
+    <h1>hello {{ name }}</h1>
+    {% endwith %}
+    """
+    create_sqlar_file(db, "template.html", dedent(template).encode())
+    app = make_app(db)
+    client = httpx.Client(app=app)
+    response = client.get("http://test/")
+    assert response.status_code == 200
+    assert response.text.strip() == "<h1>hello arg</h1>"
     assert response.headers["Content-Type"] == "text/html"
     assert response.headers["Content-Length"] == "21"
 

--- a/tests/test_exists.py
+++ b/tests/test_exists.py
@@ -1,4 +1,4 @@
-from .utils import create_route
+from .utils import create_route, create_sqlar_file
 from sqlsite.exists import run_existsquery
 from sqlsite.wsgi import make_app
 
@@ -15,6 +15,12 @@ def test_existsquery_returns_false(db):
 
 def test_missing_existsquery_returns_true(db):
     assert run_existsquery(db, "", {})
+
+
+def test_existsquery_in_file(db):
+    query = "SELECT 0"
+    create_sqlar_file(db, "query.sql", query.encode())
+    assert not run_existsquery(db, "file=query.sql", {})
 
 
 def test_existsquery_request(db):

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,0 +1,13 @@
+from .utils import create_sqlar_file
+from sqlsite.sql import maybe_get_sql_from_file
+
+
+def test_raw_query(db):
+    query = "SELECT VALUES('hi')"
+    assert maybe_get_sql_from_file(db, query) == query
+
+
+def test_query_from_file(db):
+    query = "SELECT VALUES('hi')"
+    create_sqlar_file(db, "query.sql", query.encode())
+    assert maybe_get_sql_from_file(db, "file=query.sql") == query


### PR DESCRIPTION
Fixes #5 

Anywhere that an SQL query was previously accepted, SQLSite now accepts `file=somefilename.sql`, which will load SQL contained in a file called `somefilename.sql` inside the SQLite Archive. This includes:

* The `sql` function in templates.
* The `existsquery` column.
* The config for the `json` handler.
* The config for the `redirect` hander.