### PR TITLE
Fix httpx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ apsw==3.9.2.post1
 autoflake==1.3.1
 black==19.10b0
 flake8==3.7.9
-httpx==0.11.0
+httpx==0.11.1
 isort==4.3.21
 Jinja2==2.10.3
 misaka==2.1.1

--- a/tests/handlers/test_static.py
+++ b/tests/handlers/test_static.py
@@ -2,10 +2,8 @@ from ..utils import create_route, create_sqlar_file
 from sqlsite.wsgi import make_app
 
 import httpx
-import pytest
 
 
-@pytest.mark.skip("Something weird is going on with httpx")
 def test_static_handler(db):
     create_route(db, "<path:name>", "static", config="")
     create_sqlar_file(db, "hello.txt", b"hello")


### PR DESCRIPTION
Now https://github.com/encode/httpx/issues/756 is fixed in `httpx`, we can unskip the test that was broken due to it.