### PR TITLE
Fix charset and content length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correctly add charset to Content-Type header for text responses.
+- Fix Content-Length header when body contains non-ASCII characters.
+
 ## [0.0.2] - 2019-01-14
 
 ### Added

--- a/sqlsite/handlers.py
+++ b/sqlsite/handlers.py
@@ -4,7 +4,7 @@ from .responses import (
     JSONResponse,
     NotFoundResponse,
     PermanentRedirectResponse,
-    Response,
+    PlainTextResponse,
     StreamingResponse,
 )
 from .sql import maybe_get_sql_from_file
@@ -20,7 +20,7 @@ except ImportError:
 
 
 def hello(request):
-    return Response(content="Hello from SQLSite")
+    return PlainTextResponse(content="Hello from SQLSite")
 
 
 def json(request):

--- a/sqlsite/responses.py
+++ b/sqlsite/responses.py
@@ -5,12 +5,18 @@ import json
 
 class Response:
     def __init__(
-        self, status=HTTPStatus.OK, headers=[], content="", content_type="text/plain"
+        self,
+        status=HTTPStatus.OK,
+        headers=[],
+        content="",
+        content_type="text/plain",
+        charset=None,
     ):
         self.status = status
         self.headers = headers
         self.content = content
         self.content_type = content_type
+        self.charset = charset
 
     def get_status_line(self):
         return f"{self.status.value} {self.status.phrase}"
@@ -30,29 +36,39 @@ class Response:
         return ("Content-Length", str(len(self.content)))
 
     def get_content_type_header(self):
-        return ("Content-Type", self.content_type)
+        return (
+            "Content-Type",
+            f"{self.content_type}; charset={self.charset}"
+            if self.charset
+            else self.content_type,
+        )
 
 
-class ErrorResponse(Response):
+class PlainTextResponse(Response):
+    def __init__(self, *args, **kwargs):
+        super().__init__(content_type="text/plain", charset="utf-8", *args, **kwargs)
+
+
+class ErrorResponse(PlainTextResponse):
     def __init__(self):
         super().__init__(
             status=HTTPStatus.INTERNAL_SERVER_ERROR, content="Server Error"
         )
 
 
-class NotFoundResponse(Response):
+class NotFoundResponse(PlainTextResponse):
     def __init__(self):
         super().__init__(status=HTTPStatus.NOT_FOUND, content="Not Found")
 
 
-class PermanentRedirectResponse(Response):
+class PermanentRedirectResponse(PlainTextResponse):
     def __init__(self, redirect_to):
         super().__init__(
             status=HTTPStatus.MOVED_PERMANENTLY, headers=[("Location", redirect_to)]
         )
 
 
-class MethodNotAllowedResponse(Response):
+class MethodNotAllowedResponse(PlainTextResponse):
     def __init__(self):
         super().__init__(
             status=HTTPStatus.METHOD_NOT_ALLOWED, content="Method not allowed"
@@ -66,16 +82,19 @@ class JSONResponse(Response):
 
 class HTMLResponse(Response):
     def __init__(self, *args, **kwargs):
-        super().__init__(content_type="text/html", *args, **kwargs)
+        super().__init__(content_type="text/html", charset="utf-8", *args, **kwargs)
 
 
 class StreamingResponse(Response):
-    def __init__(self, headers, content_iterable, content_type, content_length=None):
+    def __init__(
+        self, headers, content_iterable, content_type, content_length=None, charset=None
+    ):
         self.status = HTTPStatus.OK
         self.headers = headers
         self.content_iterable = content_iterable
         self.content_type = content_type
         self.content_length = content_length
+        self.charset = charset
 
     def get_content(self):
         return self.content_iterable

--- a/sqlsite/responses.py
+++ b/sqlsite/responses.py
@@ -14,7 +14,8 @@ class Response:
     ):
         self.status = status
         self.headers = headers
-        self.content = content
+        self.content = content.encode("utf-8")
+        self.content_length = len(self.content)
         self.content_type = content_type
         self.charset = charset
 
@@ -30,10 +31,10 @@ class Response:
         return [header for header in headers if header]
 
     def get_content(self):
-        return [self.content.encode("utf-8")]
+        return [self.content]
 
     def get_content_length_header(self):
-        return ("Content-Length", str(len(self.content)))
+        return ("Content-Length", str(self.content_length))
 
     def get_content_type_header(self):
         return (

--- a/tests/handlers/test_template.py
+++ b/tests/handlers/test_template.py
@@ -13,7 +13,7 @@ def test_template_handler(db):
     response = client.get("http://test/world/")
     assert response.status_code == 200
     assert response.text == "<h1>hello world</h1>"
-    assert response.headers["Content-Type"] == "text/html"
+    assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert response.headers["Content-Length"] == "20"
 
 
@@ -30,7 +30,7 @@ def test_template_with_query(db):
     response = client.get("http://test/")
     assert response.status_code == 200
     assert response.text.strip() == "<h1>hello sql</h1>"
-    assert response.headers["Content-Type"] == "text/html"
+    assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert response.headers["Content-Length"] == "21"
 
 
@@ -47,7 +47,7 @@ def test_template_with_query_and_params(db):
     response = client.get("http://test/")
     assert response.status_code == 200
     assert response.text.strip() == "<h1>hello arg</h1>"
-    assert response.headers["Content-Type"] == "text/html"
+    assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert response.headers["Content-Length"] == "21"
 
 
@@ -66,7 +66,7 @@ def test_template_with_query_in_file(db):
     response = client.get("http://test/")
     assert response.status_code == 200
     assert response.text.strip() == "<h1>hello sql</h1>"
-    assert response.headers["Content-Type"] == "text/html"
+    assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert response.headers["Content-Length"] == "21"
 
 
@@ -88,5 +88,5 @@ def test_markdown(db):
     response = client.get("http://test/")
     assert response.status_code == 200
     assert response.text.strip() == "<h1>hello markdown</h1>"
-    assert response.headers["Content-Type"] == "text/html"
+    assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert response.headers["Content-Length"] == "24"

--- a/tests/handlers/test_template.py
+++ b/tests/handlers/test_template.py
@@ -90,3 +90,12 @@ def test_markdown(db):
     assert response.text.strip() == "<h1>hello markdown</h1>"
     assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert response.headers["Content-Length"] == "24"
+
+
+def test_content_length_correct_with_non_ascii_characters(db):
+    create_route(db, "", "template", config="template.html")
+    create_sqlar_file(db, "template.html", "café".encode("utf-8"))
+    app = make_app(db)
+    client = httpx.Client(app=app)
+    response = client.get("http://test/")
+    assert response.headers["Content-Length"] == str(len(response.content))

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -11,7 +11,7 @@ def test_hello_world(db):
     response = client.get("http://test/")
     assert response.status_code == 200
     assert response.text == "Hello from SQLSite"
-    assert response.headers["Content-Type"] == "text/plain"
+    assert response.headers["Content-Type"] == "text/plain; charset=utf-8"
     assert response.headers["Content-Length"] == "18"
 
 
@@ -22,7 +22,7 @@ def test_not_found(db):
     response = client.get("http://test/notfound")
     assert response.status_code == 404
     assert response.text == "Not Found"
-    assert response.headers["Content-Type"] == "text/plain"
+    assert response.headers["Content-Type"] == "text/plain; charset=utf-8"
 
 
 def test_add_trailing_slash(db):


### PR DESCRIPTION
Fixes #12 

* `Content-Type` header for text responses now contains `charset=utf-8`
* Use length of encoded body in bytes rather than characters to set `Content-Length` header. Fixes case when body contains non-ASCII characters.