### PR TITLE
Querystring support (WIP)

### DIFF
--- a/sqlsite/handlers.py
+++ b/sqlsite/handlers.py
@@ -80,10 +80,7 @@ def template(request):
         params = params or {}
         return request.db.cursor().execute(sql, params).fetchall()
 
-    context = {
-        "sql": sql,
-        "url": request.route.url_params,
-    }
+    context = {"sql": sql, "url": request.route.url_params, "query": request.query}
     content = template.render(context)
     return HTMLResponse(content=content)
 

--- a/sqlsite/request.py
+++ b/sqlsite/request.py
@@ -1,9 +1,13 @@
+from urllib.parse import parse_qs
+
+
 class Request:
-    __slots__ = ["path", "method", "db", "route"]
+    __slots__ = ["path", "method", "query", "db", "route"]
 
     def __init__(self, environ, db):
         self.method = environ["REQUEST_METHOD"].upper()
         self.path = get_str_from_wsgi(environ, "PATH_INFO", "/").replace("/", "", 1)
+        self.query = parse_qs(get_str_from_wsgi(environ, "QUERY_STRING", ""))
         self.db = db
         self.route = None
 

--- a/tests/handlers/test_template.py
+++ b/tests/handlers/test_template.py
@@ -99,3 +99,13 @@ def test_content_length_correct_with_non_ascii_characters(db):
     client = httpx.Client(app=app)
     response = client.get("http://test/")
     assert response.headers["Content-Length"] == str(len(response.content))
+
+
+def test_query_string_available_in_template(db):
+    create_route(db, "", "template", config="template.html")
+    create_sqlar_file(db, "template.html", b"<h1>hello {{ query.name[0] }}</h1>")
+    app = make_app(db)
+    client = httpx.Client(app=app)
+    response = client.get("http://test/?name=world")
+    assert response.status_code == 200
+    assert response.text == "<h1>hello world</h1>"

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -11,3 +11,16 @@ def test_basic_request(db):
     assert request.path == "test/"
     assert request.db is db
     assert request.route is None
+
+
+def test_query_string(db):
+    environ = {
+        "REQUEST_METHOD": "get",
+        "PATH_INFO": "/test/",
+        "QUERY_STRING": "key1=value1&key2=value2",
+    }
+    request = Request(environ, db)
+    assert request.query == {
+        "key1": ["value1"],
+        "key2": ["value2"],
+    }

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,13 @@
+from sqlsite.request import Request
+
+
+def test_basic_request(db):
+    environ = {
+        "REQUEST_METHOD": "get",
+        "PATH_INFO": "/test/",
+    }
+    request = Request(environ, db)
+    assert request.method == "GET"
+    assert request.path == "test/"
+    assert request.db is db
+    assert request.route is None


### PR DESCRIPTION
Fixes #13 

Having done a bit of work on this, I'm not totally sure this is a good idea.

1. Where should the querystring values be available? Just in templates? Or should the JSON handler have access to them too?
2. If the JSON handle should have access, how will that work? Currently the SQL is just bound with the params from the URL - will the URL and query params need to be namespaced or should they just be smashed into the same dict? Which should take precedence in that case?
3. At the moment, the query is a dict where the values are _lists_, because `?foo=bar&foo=another` is valid. Do I need to implement some sort of `MultiValueDict` to make this nicer?

This all seems like it might be a bit overcomplicated.. 🤔 